### PR TITLE
Added whitespace trimming to cell_id and barcodes

### DIFF
--- a/src/cellbarcode.cpp
+++ b/src/cellbarcode.cpp
@@ -39,7 +39,10 @@ void Barcode::read_anno(string fn)
         string barcode;
 
         std::getline(linestream, cell_id, sep);
+        cell_id = trim_whitespace(cell_id);
+
         std::getline(linestream, barcode, sep);
+        barcode = trim_whitespace(barcode);
 
         barcode_dict[barcode] = cell_id;
 

--- a/src/cellbarcode.cpp
+++ b/src/cellbarcode.cpp
@@ -33,7 +33,7 @@ void Barcode::read_anno(string fn)
     {
         std::stringstream linestream(line);
 
-        if (trim_whitespace(linstream.str()) == "") continue;
+        if (trim_whitespace(linestream.str()) == "") continue;
 
         string cell_id;
         string barcode;

--- a/src/parsecount.cpp
+++ b/src/parsecount.cpp
@@ -130,7 +130,7 @@ void write_mat(string fn, std::unordered_map<string, std::vector<int>> gene_cnt_
 void write_stat(string cnt_fn, string stat_fn, std::vector<int> UMI_dup_count, std::unordered_map<string, UMI_dedup_stat> UMI_dedup_stat_dict)
 {
     std::ofstream cnt_file(cnt_fn);
-    cnt_file << "duplication number,count" << std::endl;
+    cnt_file << "duplication_number,count" << std::endl;
     for (int i=0; i<UMI_dup_count.size(); i++)
     {
         cnt_file << i+1 << "," << UMI_dup_count[i] << std::endl;
@@ -138,7 +138,7 @@ void write_stat(string cnt_fn, string stat_fn, std::vector<int> UMI_dup_count, s
     cnt_file.close();
 
     std::ofstream stat_file(stat_fn);
-    stat_file << "cell_id,number of filtered gene,number of corrected UMI,UMI A percentage,UMI T percentage,UMI G percentage,UMI C percentage" << std::endl;
+    stat_file << "cell_id,number_of_filtered_gene,number_of_corrected_UMI,UMI_A_percentage,UMI_T_percentage,UMI_G_percentage,UMI_C_percentage" << std::endl;
     for (auto const& n : UMI_dedup_stat_dict)
     {
         stat_file << n.first << "," << n.second.filtered_gene << "," << n.second.corrected_UMI << "," \

--- a/src/utils.h
+++ b/src/utils.h
@@ -55,4 +55,7 @@ std::vector<std::string> split(const std::string &s, char delim);
 
 std::string padding(int count, int zero_num);
 
+// trim leading and trailing whitespaces
+std::string trim_whitespace(const std::string &str);
+
 #endif


### PR DESCRIPTION
Trim leading and trailing whitespaces from `cell_id` and `barcode` strings. Not sure if good idea.